### PR TITLE
Fix valid if success + add --only to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install -g @open-rpc/test-coverage
 
 
 ```
-open-rpc-test-coverage -s https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/simple-math-openrpc.json --transport=http --reporter=console --skipMethods=addition
+open-rpc-test-coverage -s https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/simple-math-openrpc.json --transport=http --reporter=console --skip=addition
 ```
 
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,7 +3,8 @@ const program = require('commander');
 const orpcCoverage = require('../build').default;
 const { parseOpenRPCDocument } = require('@open-rpc/schema-utils-js');
 
-const getSkipMethods = (input) => {
+const getMethodsArray = (input) => {
+  console.log('input===>', input);
   if (input && input.split(',').length > 0) {
     return input.split(',');
   } else {
@@ -17,11 +18,12 @@ program
   .option('-s, --schema [schema]', 'JSON string or a Path/Url pointing to an open rpc schema')
   .option('-r, --reporter <reporter>', 'Use the specified reporter [console] [json]')
   .option('-t, --transport <transport>', 'Use the specified transport [http]')
-  .option('--skipMethods <skipMethods>', 'Methods to skip')
-  .action(async () => {
+  .option('--skip <skip>', 'Methods to skip')
+  .option('--only <only>', 'Methods to only run')
+  .action(async (options) => {
     let schema;
     try {
-      schema = await parseOpenRPCDocument(program.schema);
+      schema = await parseOpenRPCDocument(options.schema);
     } catch (e) {
       console.error(e);
       process.exit(1);
@@ -30,9 +32,10 @@ program
     try {
       await orpcCoverage({
         openrpcDocument: schema,
-        transport: program.transport,
-        reporter: program.reporter,
-        skipMethods: getSkipMethods(program.skipMethods)
+        transport: options.transport,
+        reporter: options.reporter,
+        skip: getMethodsArray(options.skip),
+        only: getMethodsArray(options.only),
       });
     } catch (e) {
       console.error(e);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,6 @@ const orpcCoverage = require('../build').default;
 const { parseOpenRPCDocument } = require('@open-rpc/schema-utils-js');
 
 const getMethodsArray = (input) => {
-  console.log('input===>', input);
   if (input && input.split(',').length > 0) {
     return input.split(',');
   } else {

--- a/src/coverage.test.ts
+++ b/src/coverage.test.ts
@@ -83,7 +83,7 @@ describe("coverage", () => {
     });
     it("can call the reporter with the results", (done) => {
       const reporter = (callResults: any[], schema: OpenrpcDocument) => {
-        expect(callResults[0].result.foo).toBe("bar");
+        expect(callResults[0].result).toBe(true);
         done();
       };
       const transport = async (url: string, method: string, params: any[]) => {

--- a/src/coverage.test.ts
+++ b/src/coverage.test.ts
@@ -1,6 +1,5 @@
 import coverage from "./coverage";
 import { OpenrpcDocument } from "@open-rpc/meta-schema";
-import consoleReporter from "./reporters/console";
 
 const mockSchema = {
   openrpc: "1.0.0",
@@ -82,7 +81,7 @@ describe("coverage", () => {
         only: [],
       });
     });
-    it.only("can call the reporter with the results", (done) => {
+    it("can call the reporter with the results", (done) => {
       const reporter = (callResults: any[], schema: OpenrpcDocument) => {
         expect(callResults[0].result.foo).toBe("bar");
         done();
@@ -91,7 +90,7 @@ describe("coverage", () => {
         return { result: true };
       };
       coverage({
-        reporter: consoleReporter,
+        reporter,
         transport,
         openrpcDocument: mockSchema,
         skip: [],
@@ -109,7 +108,7 @@ describe("coverage", () => {
         return Promise.resolve({});
       };
       coverage({
-        reporter: consoleReporter,
+        reporter,
         transport,
         openrpcDocument: mockSchema,
         skip: [],

--- a/src/coverage.test.ts
+++ b/src/coverage.test.ts
@@ -1,5 +1,6 @@
 import coverage from "./coverage";
 import { OpenrpcDocument } from "@open-rpc/meta-schema";
+import consoleReporter from "./reporters/console";
 
 const mockSchema = {
   openrpc: "1.0.0",
@@ -24,6 +25,45 @@ const mockSchema = {
         },
       },
     },
+    {
+      name: "bar",
+      params: [
+        {
+          name: "barParam",
+          required: true,
+          schema: {
+            type: "string",
+            enum: ["bar"],
+          },
+        },
+        {
+          name: "barParam2",
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      result: {
+        name: "barResult",
+        schema: {
+          type: "boolean",
+        },
+      },
+      examples: [
+        {
+          name: "fooExample",
+          summary: "foo example",
+          description: "this is an example of foo",
+          params: [],
+          result: {
+            name: "fooResult",
+            schema: {
+              type: "boolean",
+            },
+          },
+        },
+      ],
+    },
   ],
 } as OpenrpcDocument;
 
@@ -38,22 +78,24 @@ describe("coverage", () => {
         reporter,
         transport,
         openrpcDocument: mockSchema,
-        skipMethods: [],
+        skip: [],
+        only: [],
       });
     });
-    it("can call the reporter with the results", (done) => {
+    it.only("can call the reporter with the results", (done) => {
       const reporter = (callResults: any[], schema: OpenrpcDocument) => {
         expect(callResults[0].result.foo).toBe("bar");
         done();
       };
-      const transport = (url: string, method: string, params: any[]) => {
-        return Promise.resolve({ result: { foo: "bar" } });
+      const transport = async (url: string, method: string, params: any[]) => {
+        return { result: true };
       };
       coverage({
-        reporter,
+        reporter: consoleReporter,
         transport,
         openrpcDocument: mockSchema,
-        skipMethods: [],
+        skip: [],
+        only: [],
       });
     });
   });
@@ -67,10 +109,11 @@ describe("coverage", () => {
         return Promise.resolve({});
       };
       coverage({
-        reporter,
+        reporter: consoleReporter,
         transport,
         openrpcDocument: mockSchema,
-        skipMethods: [],
+        skip: [],
+        only: [],
       });
     });
   });

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -106,7 +106,6 @@ export default async (options: IOptions) => {
     } catch (e) {
       exampleCall.valid = false;
       exampleCall.requestError = e;
-      throw e;
     }
   }
 

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -4,7 +4,8 @@ import {
   ExampleObject,
   JSONSchema,
   ContentDescriptorObject,
-  Servers
+  Servers,
+  MethodObjectParams
 } from "@open-rpc/meta-schema";
 const jsf = require("json-schema-faker"); // tslint:disable-line
 import Ajv from "ajv";
@@ -16,7 +17,8 @@ const getFakeParams = (params: any[]): any[] => {
 
 interface IOptions {
   openrpcDocument: OpenrpcDocument;
-  skipMethods: string[];
+  skip: string[];
+  only: string[];
   transport(url: string, method: string, params: any[]): PromiseLike<any>;
   reporter(value: any[], schema: OpenrpcDocument): any;
 }
@@ -33,9 +35,21 @@ export interface ExampleCall {
   requestError?: any;
 }
 
+const paramsToObj = (params: any[], methodParams: ContentDescriptorObject[]): any => {
+  return params.reduce((acc, val, i) => {
+    acc[methodParams[i].name] = val;
+    return acc;
+  }, {});
+}
+
 export default async (options: IOptions) => {
   const filteredMethods = options.openrpcDocument.methods
-    .filter(({name}) => !options.skipMethods.includes(name));
+    .filter(({name}) => !options.skip.includes(name))
+    .filter(({name}) => options.only.length === 0 || options.only.includes(name));
+
+  if (filteredMethods.length === 0) {
+    throw new Error("No methods to test");
+  }
 
   const exampleCalls: ExampleCall[] = [];
 
@@ -45,9 +59,12 @@ export default async (options: IOptions) => {
     filteredMethods.forEach((method) => {
       if (method.examples === undefined || method.examples.length === 0) {
         for (let i = 0; i < 10; i++) {
+          const p = getFakeParams(method.params);
+          // handle object or array case
+          const params = method.paramStructure === "by-name" ? paramsToObj(p, method.params as ContentDescriptorObject[]) : p;
           exampleCalls.push({
             methodName: method.name,
-            params: getFakeParams(method.params),
+            params,
             url,
             resultSchema: (method.result as ContentDescriptorObject).schema
           });
@@ -56,9 +73,11 @@ export default async (options: IOptions) => {
       }
 
       (method.examples as ExamplePairingObject[]).forEach((ex) => {
+        const p = (ex.params as ExampleObject[]).map((e) => e.value);
+        const params = method.paramStructure === "by-name" ? paramsToObj(p, method.params as ContentDescriptorObject[]) : p;
         exampleCalls.push({
           methodName: method.name,
-          params: (ex.params as ExampleObject[]).map((e) => e.value),
+          params,
           url,
           resultSchema: (method.result as ContentDescriptorObject).schema,
           expectedResult: (ex.result as ExampleObject).value,
@@ -80,11 +99,14 @@ export default async (options: IOptions) => {
         if (ajv.errors && ajv.errors.length > 0) {
           exampleCall.valid = false;
           exampleCall.reason = JSON.stringify(ajv.errors);
+        } else {
+          exampleCall.valid = true;
         }
       }
     } catch (e) {
       exampleCall.valid = false;
       exampleCall.requestError = e;
+      throw e;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ const transports = {
 
 interface IOptions {
   openrpcDocument: OpenrpcDocument;
-  skipMethods?: string[];
+  skip?: string[];
+  only?: string[];
   reporter: "console" | "json";
   transport: "http";
 }
@@ -24,7 +25,8 @@ export default async (options: IOptions) => {
   return coverage({
     reporter: reporters[options.reporter || "console"],
     openrpcDocument: options.openrpcDocument,
-    skipMethods: options.skipMethods || [],
+    skip: options.skip || [],
+    only: options.only || [],
     transport: transports[options.transport || "http"],
   });
 };


### PR DESCRIPTION
this fixes an issue where it could report and error when there wasn't one.

this also adds `--only` to the CLI to only run certain methods.

this also changes `--skipMethods` to `--skip` to go along with `--only`