### PR TITLE
fix: example rule now falls back to ajv to check the result against the schema

### DIFF
--- a/src/coverage.test.ts
+++ b/src/coverage.test.ts
@@ -122,7 +122,7 @@ describe("coverage", () => {
   describe("rules", () => {
     it("can call multiple rules with different async or sync lifecycle functions", async () => {
       const reporter = new EmptyReporter();
-      const transport = () => Promise.resolve({});
+      const transport = () => Promise.resolve({result: false});
       const openrpcDocument = mockSchema;
       const exampleRule = new ExamplesRule({ skip: ["foo"], only: ["baz"] });
       const jsonSchemaFakerRule = new JsonSchemaFakerRule({ skip: ["baz"], only: [] });

--- a/src/coverage.test.ts
+++ b/src/coverage.test.ts
@@ -122,7 +122,7 @@ describe("coverage", () => {
   describe("rules", () => {
     it("can call multiple rules with different async or sync lifecycle functions", async () => {
       const reporter = new EmptyReporter();
-      const transport = () => Promise.resolve({result: false});
+      const transport = () => Promise.resolve({});
       const openrpcDocument = mockSchema;
       const exampleRule = new ExamplesRule({ skip: ["foo"], only: ["baz"] });
       const jsonSchemaFakerRule = new JsonSchemaFakerRule({ skip: ["baz"], only: [] });

--- a/src/rules/examples-rule.test.ts
+++ b/src/rules/examples-rule.test.ts
@@ -1,0 +1,165 @@
+
+import ExamplesRule from "./examples-rule";
+
+describe("ExamplesRule", () => {
+  it("should validate example calls with ajv as the fallback", () => {
+    const rule = new ExamplesRule();
+    const openrpcDocument = {
+      openrpc: "1.0.0",
+      info: {
+        title: "my api",
+        version: "0.0.0-development",
+      },
+      servers: [
+        {
+          name: "my api",
+          url: "http://localhost:3333",
+        },
+      ],
+      methods: [
+        {
+          name: "foo",
+          params: [],
+          result: {
+            name: "fooResult",
+            schema: {
+              type: "string",
+            },
+          },
+          examples: [
+            {
+              name: "fooExample",
+              summary: "foo example",
+              description: "this is an example of foo",
+              params: [
+                {
+                  name: "barParam",
+                  value: "bar",
+                },
+                {
+                  name: "barParam2",
+                  value: "bar",
+                }
+              ],
+              result: {
+                name: "fooResult",
+                value: "potato",
+              }
+            }
+          ]
+        },
+      ],
+    } as any;
+    const calls = rule.getCalls(openrpcDocument, openrpcDocument.methods[0]);
+    calls[0].result = "different";
+    const result = rule.validateCall(calls[0]);
+    expect(result.valid).toBe(true);
+  });
+  it("should not validate example calls with ajv as a callback", () => {
+    const rule = new ExamplesRule();
+    const openrpcDocument = {
+      openrpc: "1.0.0",
+      info: {
+        title: "my api",
+        version: "0.0.0-development",
+      },
+      servers: [
+        {
+          name: "my api",
+          url: "http://localhost:3333",
+        },
+      ],
+      methods: [
+        {
+          name: "foo",
+          params: [],
+          result: {
+            name: "fooResult",
+            schema: {
+              type: "string",
+            },
+          },
+          examples: [
+            {
+              name: "fooExample",
+              summary: "foo example",
+              description: "this is an example of foo",
+              params: [
+                {
+                  name: "barParam",
+                  value: "bar",
+                },
+                {
+                  name: "barParam2",
+                  value: "bar",
+                }
+              ],
+              result: {
+                name: "fooResult",
+                value: "potato",
+              }
+            }
+          ]
+        },
+      ],
+    } as any;
+    const calls = rule.getCalls(openrpcDocument, openrpcDocument.methods[0]);
+    calls[0].result = false;
+    const result = rule.validateCall(calls[0]);
+    expect(result.valid).toBe(false);
+  });
+  it("should not validate example calls with ajv as a callback and just give a good error message if the schema doesnt parse", () => {
+    const rule = new ExamplesRule();
+    const openrpcDocument = {
+      openrpc: "1.0.0",
+      info: {
+        title: "my api",
+        version: "0.0.0-development",
+      },
+      servers: [
+        {
+          name: "my api",
+          url: "http://localhost:3333",
+        },
+      ],
+      methods: [
+        {
+          name: "foo",
+          params: [],
+          result: {
+            name: "fooResult",
+            schema: {
+              type: "string",
+              unevaluatedProperties: false,
+            },
+          },
+          examples: [
+            {
+              name: "fooExample",
+              summary: "foo example",
+              description: "this is an example of foo",
+              params: [
+                {
+                  name: "barParam",
+                  value: "bar",
+                },
+                {
+                  name: "barParam2",
+                  value: "bar",
+                }
+              ],
+              result: {
+                name: "fooResult",
+                value: "potato",
+              }
+            }
+          ]
+        },
+      ],
+    } as any;
+    const calls = rule.getCalls(openrpcDocument, openrpcDocument.methods[0]);
+    calls[0].result = false;
+    const result = rule.validateCall(calls[0]);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/src/rules/examples-rule.ts
+++ b/src/rules/examples-rule.ts
@@ -67,7 +67,6 @@ class ExamplesRule implements Rule {
           return call;
         } catch (e: any) {
           call.valid = false;
-          call.reason = e.message;
         }
       }
       if (!call.valid) {


### PR DESCRIPTION
we were having issues with methods like `web3_clientVersion` where we have an example in the spec that doesn't match exactly the example but the schema still matches.